### PR TITLE
Move laravel/pint to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
     "illuminate/support": "^10.0|^11.0|^12.0",
     "illuminate/bus": "^10.0|^11.0|^12.0",
     "illuminate/database": "^10.0|^11.0|^12.0",
-    "illuminate/redis": "^10.0|^11.0|^12.0",
+    "illuminate/redis": "^10.0|^11.0|^12.0"
+  },
+  "require-dev": {
     "laravel/pint": "^1.14"
   },
   "extra": {

--- a/src/CustomBusServiceProvider.php
+++ b/src/CustomBusServiceProvider.php
@@ -20,7 +20,7 @@ class CustomBusServiceProvider extends BusServiceProvider
                     $factory = $app->make(\Illuminate\Bus\BatchFactory::class);
 
                     return new RedisBatchRepository($factory);
-                }
+                },
             );
         } else {
             // Call the parent method to retain the default behavior

--- a/src/Repositories/RedisBatchRepository.php
+++ b/src/Repositories/RedisBatchRepository.php
@@ -330,7 +330,7 @@ class RedisBatchRepository extends DatabaseBatchRepository implements BatchRepos
             $this->unserialize($batch['options']),
             CarbonImmutable::createFromTimestamp($batch['created_at']),
             isset($batch['cancelled_at']) ? CarbonImmutable::createFromTimestamp($batch['cancelled_at']) : null,
-            isset($batch['finished_at']) ? CarbonImmutable::createFromTimestamp($batch['finished_at']) : null
+            isset($batch['finished_at']) ? CarbonImmutable::createFromTimestamp($batch['finished_at']) : null,
         );
     }
 


### PR DESCRIPTION
`laravel/pint` is only needed during development, not runtime. So, this PR moves it from require to require-dev, to prevent it from being installed unnecessarily in a lot of projects. Nothing breaking or fancy, just a simple requirements-fix.

In our case, having `laravel/pint` in the `require` section causes issues, because `laravel/pint` is not (yet) compatible with later versions of `friendsofphp/php-cs-fixer` and we simply don't want to have packages installed if they're not necessary and when they're not required.