### PR TITLE
Add Laravel 13.x compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": "^8.1",
-    "laravel/framework": "^10.0|^11.0|^12.0",
+    "laravel/framework": "^10.0|^11.0|^12.0|^13.0",
     "ext-redis": "*"
   },
   "require-dev": {
@@ -22,7 +22,7 @@
     "rector/rector": "^2.2.14",
     "phpstan/phpstan": "^2.1",
     "larastan/larastan": "^3.0",
-    "orchestra/testbench": "^10.8"
+    "orchestra/testbench": "^10.8|^11.0"
   },
   "scripts": {
     "format": "php-cs-fixer fix --config=.php-cs-fixer.php",


### PR DESCRIPTION
## Summary
- Add `^13.0` to `laravel/framework` constraint
- Add `^11.0` to `orchestra/testbench` constraint

Minimal version of #4 without unnecessary indentation changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)